### PR TITLE
add unified image load util

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+build/
+dist/
+*.egg-info/
+

--- a/zhilight/models/deepseek_vl_v2.py
+++ b/zhilight/models/deepseek_vl_v2.py
@@ -25,7 +25,7 @@ from zhilight.config.dev_config import *
 from zhilight.config.deepseek_adapter import DeepseekV2Adapter
 from zhilight.llama import LLaMA, LLaMAModelConfig, QuantConfig, DistConfig
 from zhilight.loader import LLaMALoader
-
+from zhilight.utils.image_utils import load_image
 
 def load_pil_images(conversations: List[Dict[str, str]]) -> List[PIL.Image.Image]:
     pil_images = []
@@ -34,8 +34,8 @@ def load_pil_images(conversations: List[Dict[str, str]]) -> List[PIL.Image.Image
         if "images" not in message:
             continue
 
-        for image_path in message["images"]:
-            pil_img = PIL.Image.open(image_path)
+        for image_path_or_url_or_pil in message["images"]:
+            pil_img = load_image(image_path_or_url_or_pil)
             pil_img = pil_img.convert("RGB")
             pil_images.append(pil_img)
 

--- a/zhilight/utils/image_utils.py
+++ b/zhilight/utils/image_utils.py
@@ -1,0 +1,48 @@
+import os
+import requests
+from typing import Union, Optional, Callable
+
+import PIL.Image
+import PIL.ImageOps
+
+def load_image(
+    image: Union[str, PIL.Image.Image], convert_method: Optional[Callable[[PIL.Image.Image], PIL.Image.Image]] = None
+) -> PIL.Image.Image:
+    """
+    Loads `image` to a PIL Image.
+
+    Args:
+        image (`str` or `PIL.Image.Image`):
+            The image to convert to the PIL Image format.
+        convert_method (Callable[[PIL.Image.Image], PIL.Image.Image], *optional*):
+            A conversion method to apply to the image after loading it. When set to `None` the image will be converted
+            "RGB".
+
+    Returns:
+        `PIL.Image.Image`:
+            A PIL Image.
+    """
+    if isinstance(image, str):
+        if image.startswith("http://") or image.startswith("https://"):
+            image = PIL.Image.open(requests.get(image, stream=True).raw)
+        elif os.path.isfile(image):
+            image = PIL.Image.open(image)
+        else:
+            raise ValueError(
+                f"Incorrect path or URL. URLs must start with `http://` or `https://`, and {image} is not a valid path."
+            )
+    elif isinstance(image, PIL.Image.Image):
+        image = image
+    else:
+        raise ValueError(
+            "Incorrect format used for the image. Should be a URL linking to an image, a local path, or a PIL image."
+        )
+
+    image = PIL.ImageOps.exif_transpose(image)
+
+    if convert_method is not None:
+        image = convert_method(image)
+    else:
+        image = image.convert("RGB")
+
+    return image


### PR DESCRIPTION
服务时一般是穿 base64 或 pil image 过来，而目前 vlm 加载图像时只能根据本地文件路径加载，这样只能存成一个本地临时文件，再读进来，比较低效。

参考 diffusers 的[图片加载 util](https://github.com/huggingface/diffusers/blob/7fb481f840b5d73982cafd1affe89f21a5c0b20b/src/diffusers/utils/loading_utils.py#L13) ，添加了统一的图像加载方法，可兼容从 image url/path/pil 加载。