### PR TITLE
Fix attn_encode_group

### DIFF
--- a/examples/offline_inference.py
+++ b/examples/offline_inference.py
@@ -40,4 +40,4 @@ prompts = [
 with DynamicBatchGenerator(dyn_config, model) as generator:
     results = generator.batch_generate(prompts, arg)
     for i in range(len(prompts)):
-        print(f"{prompts[i]} => {results[0].outputs[0].text}")
+        print(f"{prompts[i]} => {results[i].outputs[0].text}")

--- a/src/nn/attention/attention.cpp
+++ b/src/nn/attention/attention.cpp
@@ -515,6 +515,7 @@ Tensor Attention::impl::NormalImpl::attn_encode_group(
             auto fa_out = v_t.view(h_q.size());
             // TODO: do varlen batch prefill, interface is ready, but need organize input/output/kv_cache
             flash_decoding(ctx, h_q, key_cache, val_cache, &fa_out);
+            offset += input_len;
             continue;
         }
 


### PR DESCRIPTION
Fix: Update offset correctly in attn_encode_group for BSHD mode

Problem Description:
In the `nn::Attention::impl::NormalImpl::attn_encode_group` method, when the `ctx.is_BSHD()` condition is true, the code block executes `flash_decoding` and then uses `continue` to proceed to the next iteration of the `for` loop. However, the `offset` variable was not updated (`offset += input_len;`) before this `continue` statement.

This caused subsequent loop iterations to use an incorrect `offset` value when slicing tensors with `h_q_enc.slice_dim0_len`, `h_k_enc.slice_dim0_len`, and `h_v_enc.slice_dim0_len`, leading to calculation errors.

Fix:
Added `offset += input_len;` before the `continue` statement to ensure that the `offset` is correctly incremented by `input_len` at the end of each loop iteration, even when `ctx.is_BSHD()` is true.

Impact:
This fix ensures that attention calculations for each sequence in the batch use the correct QKV tensor slices when operating in BSHD mode.

BTW:
Fix(examples): Correct indexing in offline_inference.py result printing