### PR TITLE
feat: Populate missing RequestMetrics values

### DIFF
--- a/src/generator/batch_generator.h
+++ b/src/generator/batch_generator.h
@@ -123,7 +123,7 @@ class BatchGenerator {
     bmengine::core::Engine* engine_;
 
     TaskQueue queue_;
-    int active_size_;
+    int active_size_ { 0 };
 
     shared_ptr<std::thread> thread_;
     volatile bool stopping_ { false };

--- a/src/py_export/py_batch_generator.cpp
+++ b/src/py_export/py_batch_generator.cpp
@@ -105,6 +105,14 @@ public:
 
     py::object get_result(float timeout);
 
+    long get_first_schedule_ts() {
+        return task_->begin_ts;
+    }
+    
+    long get_time_in_queue() {
+        return task_->begin_ts - enqueue_ts;
+    }
+
     void cancel() {
         task_->canceled = true;
     }
@@ -307,6 +315,8 @@ void define_dynamic_batch(py::module_& m) {
     py::class_<PySearchTask, shared_ptr<PySearchTask>>(m, "SearchTask")
         .def("has_result", &PySearchTask::has_result)
         .def("get_result", &PySearchTask::get_result)
+        .def("get_time_in_queue", &PySearchTask::get_time_in_queue)
+        .def("get_first_schedule_ts", &PySearchTask::get_first_schedule_ts)
         .def("input_tokens_num", &PySearchTask::input_tokens_num)
         .def("output_tokens_nums", &PySearchTask::output_tokens_nums)
         .def("cancel", &PySearchTask::cancel)

--- a/zhilight/server/openai/engine/async_llm_engine.py
+++ b/zhilight/server/openai/engine/async_llm_engine.py
@@ -217,13 +217,14 @@ class AsyncLLMEngine:
             current_iter_time = time.time()
             iter_cost = current_iter_time - last_iter_time
             if first:
-                stats.first_token_time = iter_cost
+                stats.first_token_time = current_iter_time
+                stats.first_scheduled_time = handler.task.get_first_schedule_ts() * 1e-6 
+                stats.time_in_queue = handler.task.get_time_in_queuegs() * 1e-6
                 stats.input_tokens_num = handler.input_tokens_num
                 first = False
-            else:
-                stats.first_token_time = None
             stats.output_tokens_num = sum(handler.output_tokens_nums)
             if output[0] == StreamResultType.Final:
+                stats.finished_time = time.time()
                 finished = True
             else:
                 stats.last_token_time = iter_cost


### PR DESCRIPTION
Previously, some metrics within RequestMetrics could be None. This commit ensures all metrics are populated with appropriate values, providing more complete request tracking information.

Also initializes `active_size_`  to prevent `self._c_generator.active_size()` from returning an indeterminate value initially.